### PR TITLE
First pass of Authorization Transport and some related utilities

### DIFF
--- a/egobee.go
+++ b/egobee.go
@@ -1,3 +1,37 @@
 // Package egobee encapsulates types and helper functions for interacting with
 // the ecobee REST API in Go.
 package egobee
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// authorizingTransport is a RoundTripper which includes the Access token in the
+// request headers as appropriate for accessing the ecobee API.
+type authorizingTransport struct {
+	auth      TokenStore
+	transport http.RoundTripper
+}
+
+func (t *authorizingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %v", t.auth.AccessToken()))
+	return t.transport.RoundTrip(req)
+}
+
+// Client for the ecobee API.
+type Client struct {
+	http.Client
+}
+
+// New egobee client.
+func New(ts TokenStore) *Client {
+	return &Client{
+		Client: http.Client{
+			Transport: &authorizingTransport{
+				auth:      ts,
+				transport: http.DefaultTransport,
+			},
+		},
+	}
+}

--- a/egobee_test.go
+++ b/egobee_test.go
@@ -1,0 +1,44 @@
+package egobee
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type fakeTokenStore struct {
+}
+
+func (s *fakeTokenStore) AccessToken() string {
+	return "thisisanaccesstoken"
+}
+
+func (s *fakeTokenStore) RefreshToken() string {
+	return "thisisarefreshtoken"
+}
+
+func (s *fakeTokenStore) ValidFor() time.Duration {
+	return time.Minute * 30
+}
+
+func TestAuthorizingTransport(t *testing.T) {
+	clientForTest := http.Client{
+		Transport: &authorizingTransport{
+			auth:      &fakeTokenStore{},
+			transport: http.DefaultTransport,
+		},
+	}
+	serverForTest := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got := r.Header.Get("Authorization")
+		if got != "Bearer thisisanaccesstoken" {
+			t.Errorf(`invalide Authorization header; got: %q, want: "Bearer thisisanaccesstoken"`, got)
+		}
+	}))
+	defer serverForTest.Close()
+	res, err := clientForTest.Get(serverForTest.URL)
+	if err != nil {
+		t.Errorf("unexpected error GETting from test server: %v", err)
+	}
+	res.Body.Close()
+}

--- a/error.go
+++ b/error.go
@@ -1,0 +1,28 @@
+package egobee
+
+// APIError returned by ecobee.
+type APIError string
+
+// Possible API Errors
+var (
+	APIErrorAccessDenied         APIError = "access_denied"
+	APIErrorInvalidRequest       APIError = "invalid_request"
+	APIErrorInvalidClient        APIError = "invalid_client"
+	APIErrorInvalidGrant         APIError = "invalid_grant"
+	APIErrorUnauthorizeClient    APIError = "unauthorized_client"
+	APIErrorUnsupportedGrantType APIError = "unsupported_grant_type"
+	APIErrorInvalidScope         APIError = "invalid_scope"
+	APIErrorNotSupported         APIError = "not_supported"
+	APIErrorAccountLocked        APIError = "account_locked"
+	APIErrorAccountDisabled      APIError = "account_disabled"
+	APIErrorAuthorizationPending APIError = "authorization_pending"
+	APIErrorAuthorizationExpired APIError = "authorization_expired"
+	APIErrorSlowDown             APIError = "slow_down"
+)
+
+// ErrorResponse as returned from the ecobee API.
+type ErrorResponse struct {
+	Error       APIError `json:"error"`
+	Description string   `json:"error_description"`
+	URI         string   `json:"error_uri"`
+}

--- a/error.go
+++ b/error.go
@@ -1,5 +1,9 @@
 package egobee
 
+import (
+	"encoding/json"
+)
+
 // APIError returned by ecobee.
 type APIError string
 
@@ -25,4 +29,18 @@ type ErrorResponse struct {
 	Error       APIError `json:"error"`
 	Description string   `json:"error_description"`
 	URI         string   `json:"error_uri"`
+}
+
+// Parse a response payload into the receiving ErrorResponse. This will
+// naturally fail if the payload is not an ErrorResponse.
+func (r *ErrorResponse) Parse(payload []byte) error {
+	if err := json.Unmarshal(payload, r); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ParseString behaves the same as Parse, but on a string.
+func (r *ErrorResponse) ParseString(payload string) error {
+	return r.Parse([]byte(payload))
 }

--- a/error_test.go
+++ b/error_test.go
@@ -27,3 +27,47 @@ func TestUnmarshalErrorResponse(t *testing.T) {
 		t.Errorf("got: %+v, wanted: %+v", got, want)
 	}
 }
+
+func TestErrorResponse_ParseString(t *testing.T) {
+	exampleJSON := `{
+    "error": "invalid_client",
+    "error_description": "Authentication error, invalid authentication method, lack of credentials, etc.",
+    "error_uri": "https://tools.ietf.org/html/rfc6749#section-5.2"
+}`
+
+	want := &ErrorResponse{
+		Error:       APIErrorInvalidClient,
+		Description: "Authentication error, invalid authentication method, lack of credentials, etc.",
+		URI:         "https://tools.ietf.org/html/rfc6749#section-5.2",
+	}
+
+	got := &ErrorResponse{}
+	if err := got.ParseString(exampleJSON); err != nil {
+		t.Errorf("got unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got: %+v, wanted: %+v", got, want)
+	}
+}
+
+func TestErrorResponse_Parse(t *testing.T) {
+	exampleJSON := []byte(`{
+    "error": "invalid_client",
+    "error_description": "Authentication error, invalid authentication method, lack of credentials, etc.",
+    "error_uri": "https://tools.ietf.org/html/rfc6749#section-5.2"
+}`)
+
+	want := &ErrorResponse{
+		Error:       APIErrorInvalidClient,
+		Description: "Authentication error, invalid authentication method, lack of credentials, etc.",
+		URI:         "https://tools.ietf.org/html/rfc6749#section-5.2",
+	}
+
+	got := &ErrorResponse{}
+	if err := got.Parse(exampleJSON); err != nil {
+		t.Errorf("got unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got: %+v, wanted: %+v", got, want)
+	}
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,29 @@
+package egobee
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestUnmarshalErrorResponse(t *testing.T) {
+	// This JSON has stray whitespace which is preserved from the source docs.
+	exampleJSON := `{
+    "error": "invalid_client",
+    "error_description": "Authentication error, invalid authentication method, lack of credentials, etc.",
+    "error_uri": "https://tools.ietf.org/html/rfc6749#section-5.2"
+}`
+	want := &ErrorResponse{
+		Error:       APIErrorInvalidClient,
+		Description: "Authentication error, invalid authentication method, lack of credentials, etc.",
+		URI:         "https://tools.ietf.org/html/rfc6749#section-5.2",
+	}
+
+	got := &ErrorResponse{}
+	if err := json.Unmarshal([]byte(exampleJSON), got); err != nil {
+		t.Errorf("got unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got: %+v, wanted: %+v", got, want)
+	}
+}

--- a/token.go
+++ b/token.go
@@ -70,3 +70,30 @@ type TokenRefreshResponse struct {
 	RefreshToken string        `json:"refresh_token"`
 	Scope        Scope         `json:"scope"`
 }
+
+// APIError returned by ecobee.
+type APIError string
+
+// Possible API Errors
+var (
+	APIErrorAccessDenied         APIError = "access_denied"
+	APIErrorInvalidRequest       APIError = "invalid_request"
+	APIErrorInvalidClient        APIError = "invalid_client"
+	APIErrorInvalidGrant         APIError = "invalid_grant"
+	APIErrorUnauthorizeClient    APIError = "unauthorized_client"
+	APIErrorUnsupportedGrantType APIError = "unsupported_grant_type"
+	APIErrorInvalidScope         APIError = "invalid_scope"
+	APIErrorNotSupported         APIError = "not_supported"
+	APIErrorAccountLocked        APIError = "account_locked"
+	APIErrorAccountDisabled      APIError = "account_disabled"
+	APIErrorAuthorizationPending APIError = "authorization_pending"
+	APIErrorAuthorizationExpired APIError = "authorization_expired"
+	APIErrorSlowDown             APIError = "slow_down"
+)
+
+// ErrorResponse as returned from the ecobee API.
+type ErrorResponse struct {
+	Error       APIError `json:"error"`
+	Description string   `json:"error_description"`
+	URI         string   `json:"error_uri"`
+}

--- a/token.go
+++ b/token.go
@@ -70,30 +70,3 @@ type TokenRefreshResponse struct {
 	RefreshToken string        `json:"refresh_token"`
 	Scope        Scope         `json:"scope"`
 }
-
-// APIError returned by ecobee.
-type APIError string
-
-// Possible API Errors
-var (
-	APIErrorAccessDenied         APIError = "access_denied"
-	APIErrorInvalidRequest       APIError = "invalid_request"
-	APIErrorInvalidClient        APIError = "invalid_client"
-	APIErrorInvalidGrant         APIError = "invalid_grant"
-	APIErrorUnauthorizeClient    APIError = "unauthorized_client"
-	APIErrorUnsupportedGrantType APIError = "unsupported_grant_type"
-	APIErrorInvalidScope         APIError = "invalid_scope"
-	APIErrorNotSupported         APIError = "not_supported"
-	APIErrorAccountLocked        APIError = "account_locked"
-	APIErrorAccountDisabled      APIError = "account_disabled"
-	APIErrorAuthorizationPending APIError = "authorization_pending"
-	APIErrorAuthorizationExpired APIError = "authorization_expired"
-	APIErrorSlowDown             APIError = "slow_down"
-)
-
-// ErrorResponse as returned from the ecobee API.
-type ErrorResponse struct {
-	Error       APIError `json:"error"`
-	Description string   `json:"error_description"`
-	URI         string   `json:"error_uri"`
-}

--- a/token.go
+++ b/token.go
@@ -61,6 +61,8 @@ func (d *TokenDuration) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// TokenRefreshResponse is returned by the ecobee API on toke refresh.
+// See https://www.ecobee.com/home/developer/api/documentation/v1/auth/token-refresh.shtml
 type TokenRefreshResponse struct {
 	AccessToken  string        `json:"access_token"`
 	TokenType    string        `json:"token_type"`

--- a/token.go
+++ b/token.go
@@ -1,0 +1,70 @@
+package egobee
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+	"time"
+)
+
+var (
+	// ErrInvalidDuration is returned from UnmarshalJSON when the JSON does not
+	// represent a Duration.
+	ErrInvalidDuration = errors.New("invalid duration")
+
+	hasUnitRx = regexp.MustCompile("[a-zA-Z]+")
+)
+
+// Scope of a token.
+type Scope string
+
+// Possible Scopes.
+// See https://www.ecobee.com/home/developer/api/documentation/v1/auth/auth-intro.shtml
+var (
+	ScopeSmartRead  Scope = "smartRead"
+	ScopeSmartWrite Scope = "smartWrite"
+	ScopeEMSWrite   Scope = "ems"
+)
+
+// TokenDuration wraps time.Duration to add JSON (un)marshalling
+type TokenDuration struct {
+	time.Duration
+}
+
+// MarshalJSON returns JSON representation of Duration.
+func (d TokenDuration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.Duration.String())
+}
+
+// UnmarshalJSON returns a Duration from JSON representation. Since the ecobee
+// API returns durations in Seconds, values will be treated as such.
+func (d *TokenDuration) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case float64:
+		d.Duration = time.Second * time.Duration(value)
+	case string:
+		if !hasUnitRx.Match([]byte(value)) {
+			value = value + "s"
+		}
+		dv, err := time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+		d.Duration = dv
+	default:
+		return ErrInvalidDuration
+	}
+	return nil
+}
+
+type TokenRefreshResponse struct {
+	AccessToken  string        `json:"access_token"`
+	TokenType    string        `json:"token_type"`
+	ExpiresIn    TokenDuration `json:"expires_in"`
+	RefreshToken string        `json:"refresh_token"`
+	Scope        Scope         `json:"scope"`
+}

--- a/token_test.go
+++ b/token_test.go
@@ -61,3 +61,32 @@ func TestMarshalTokenDuration(t *testing.T) {
 		}
 	}
 }
+
+// TestUnmarshalTokenRefreshResponse tests that the example JSON provided on the
+// ecobee API documentation page is properly unmarshalled.
+// See https://www.ecobee.com/home/developer/api/documentation/v1/auth/token-refresh.shtml
+func TestUnmarshalTokenRefreshResponse(t *testing.T) {
+	// This JSON has stray whitespace which is preserved from the source docs.
+	exampleJSON := `{
+    "access_token": "Rc7JE8P7XUgSCPogLOx2VLMfITqQQrjg",
+    "token_type": "Bearer",
+    "expires_in": 3599,
+    "refresh_token": "og2Obost3ucRo1ofo0EDoslGltmFMe2g",
+    "scope": "smartWrite" 
+}                `
+	want := &TokenRefreshResponse{
+		AccessToken:  "Rc7JE8P7XUgSCPogLOx2VLMfITqQQrjg",
+		TokenType:    "Bearer",
+		ExpiresIn:    TokenDuration{Duration: time.Second * 3599},
+		RefreshToken: "og2Obost3ucRo1ofo0EDoslGltmFMe2g",
+		Scope:        ScopeSmartWrite,
+	}
+
+	got := &TokenRefreshResponse{}
+	if err := json.Unmarshal([]byte(exampleJSON), got); err != nil {
+		t.Errorf("unmarshal sample json: got unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("unmarshal sample json: got: %+v, wanted: %+v", got, want)
+	}
+}

--- a/token_test.go
+++ b/token_test.go
@@ -90,25 +90,3 @@ func TestUnmarshalTokenRefreshResponse(t *testing.T) {
 		t.Errorf("got: %+v, wanted: %+v", got, want)
 	}
 }
-
-func TestUnmarshalErrorResponse(t *testing.T) {
-	// This JSON has stray whitespace which is preserved from the source docs.
-	exampleJSON := `{
-    "error": "invalid_client",
-    "error_description": "Authentication error, invalid authentication method, lack of credentials, etc.",
-    "error_uri": "https://tools.ietf.org/html/rfc6749#section-5.2"
-}`
-	want := &ErrorResponse{
-		Error:       APIErrorInvalidClient,
-		Description: "Authentication error, invalid authentication method, lack of credentials, etc.",
-		URI:         "https://tools.ietf.org/html/rfc6749#section-5.2",
-	}
-
-	got := &ErrorResponse{}
-	if err := json.Unmarshal([]byte(exampleJSON), got); err != nil {
-		t.Errorf("got unexpected error: %v", err)
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got: %+v, wanted: %+v", got, want)
-	}
-}

--- a/token_test.go
+++ b/token_test.go
@@ -1,0 +1,63 @@
+package egobee
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type testJSON struct {
+	Duration TokenDuration `json:"duration"`
+}
+
+func TestUnmarshalTokenDuration(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		json string
+		want *testJSON
+	}{
+		{
+			name: "unmarshal string duration with no units",
+			json: `{"duration":"12345"}`,
+			want: &testJSON{Duration: TokenDuration{Duration: time.Second * 12345}},
+		},
+		{
+			name: "unmarshal float duration",
+			json: `{"duration":12345}`,
+			want: &testJSON{Duration: TokenDuration{Duration: time.Second * 12345}},
+		},
+		{
+			name: "unmarshal string duration with units",
+			json: `{"duration":"3h25m45s"}`,
+			want: &testJSON{Duration: TokenDuration{Duration: time.Second * 12345}},
+		},
+	} {
+		got := &testJSON{}
+		if err := json.Unmarshal([]byte(tt.json), &got); err != nil {
+			t.Errorf("%v: got unexpected error: %v", tt.name, err)
+		} else if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("%v: got: %v, wanted: %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestMarshalTokenDuration(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		val  *testJSON
+		want string
+	}{
+		{
+			name: "marshal",
+			val:  &testJSON{Duration: TokenDuration{Duration: time.Second * 12345}},
+			want: `{"duration":"3h25m45s"}`,
+		},
+	} {
+		if got, err := json.Marshal(tt.val); err != nil {
+			t.Errorf("%v: got unexpected error: %v", tt.name, err)
+		} else if string(got) != tt.want {
+			t.Errorf("%v: got: %q, wanted: %q", tt.name, got, tt.want)
+		}
+	}
+}

--- a/token_test.go
+++ b/token_test.go
@@ -84,9 +84,31 @@ func TestUnmarshalTokenRefreshResponse(t *testing.T) {
 
 	got := &TokenRefreshResponse{}
 	if err := json.Unmarshal([]byte(exampleJSON), got); err != nil {
-		t.Errorf("unmarshal sample json: got unexpected error: %v", err)
+		t.Errorf("got unexpected error: %v", err)
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("unmarshal sample json: got: %+v, wanted: %+v", got, want)
+		t.Errorf("got: %+v, wanted: %+v", got, want)
+	}
+}
+
+func TestUnmarshalErrorResponse(t *testing.T) {
+	// This JSON has stray whitespace which is preserved from the source docs.
+	exampleJSON := `{
+    "error": "invalid_client",
+    "error_description": "Authentication error, invalid authentication method, lack of credentials, etc.",
+    "error_uri": "https://tools.ietf.org/html/rfc6749#section-5.2"
+}`
+	want := &ErrorResponse{
+		Error:       APIErrorInvalidClient,
+		Description: "Authentication error, invalid authentication method, lack of credentials, etc.",
+		URI:         "https://tools.ietf.org/html/rfc6749#section-5.2",
+	}
+
+	got := &ErrorResponse{}
+	if err := json.Unmarshal([]byte(exampleJSON), got); err != nil {
+		t.Errorf("got unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got: %+v, wanted: %+v", got, want)
 	}
 }


### PR DESCRIPTION
The Authorization Transport is a RoundTripper which wraps the default HTTP transport in the egobee client and automatically adds the Access Token to all requests. The Token is stored in the TokenStore, which is a terrible API and needs reworking.

In the near future, this transport will have its own HTTP client and will manage refreshing the Access Token when necessary. We will need to change the TokenStore API to allow mutation before this happens.