### PR TITLE
The authorizingTransport allows the Client to refresh its own tokens.

### DIFF
--- a/egobee.go
+++ b/egobee.go
@@ -3,20 +3,92 @@
 package egobee
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"time"
 )
+
+const ecobeeTokenURL = "https://api.ecobee.com/token"
+
+type reauthResponse struct {
+	Err  *AuthorizationErrorResponse
+	Resp *TokenRefreshResponse
+}
+
+func (r *reauthResponse) ok() bool {
+	if r == nil {
+		return false
+	}
+	return r.Err == nil && r.Resp != nil
+}
+
+func (r *reauthResponse) err() error {
+	if r.Err != nil && r.Err.Error != "" && r.Err.Description != "" {
+		return fmt.Errorf("unable to re-authenticate: %v: %v", r.Err.Error, r.Err.Description)
+	}
+	return errors.New("unable to re-authenticate for unknown reasons")
+}
+
+func reauthResponseFromHTTPResponse(resp *http.Response) (*reauthResponse, error) {
+	r := &reauthResponse{}
+	if (resp.StatusCode / 100) != 2 {
+		r.Err = &AuthorizationErrorResponse{}
+		if err := r.Err.Populate(resp.Body); err != nil {
+			return nil, err
+		}
+	} else {
+		r.Resp = &TokenRefreshResponse{}
+		if err := r.Resp.Populate(resp.Body); err != nil {
+			return nil, err
+		}
+	}
+	return r, nil
+}
 
 // authorizingTransport is a RoundTripper which includes the Access token in the
 // request headers as appropriate for accessing the ecobee API.
 type authorizingTransport struct {
 	auth      TokenStore
 	transport http.RoundTripper
+	appID     string
 }
 
 func (t *authorizingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.shouldReauth() {
+		if err := t.reauth(); err != nil {
+			return nil, err
+		}
+	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %v", t.auth.AccessToken()))
 	return t.transport.RoundTrip(req)
+}
+
+func (t *authorizingTransport) shouldReauth() bool {
+	// TODO(cfunkhouser): make the timeout customizable.
+	return (t.auth.ValidFor() < (time.Second * 15)) || (t.auth.AccessToken() == "")
+}
+
+func (t *authorizingTransport) sendReauth(url string) (*reauthResponse, error) {
+	tokenURL := fmt.Sprintf("%v?grant_type=refresh_token&refresh_token=%v&client_id=%v", url, t.auth.RefreshToken(), t.appID)
+	resp, err := http.Post(tokenURL, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return reauthResponseFromHTTPResponse(resp)
+}
+
+func (t *authorizingTransport) reauth() error {
+	r, err := t.sendReauth(ecobeeTokenURL)
+	if err != nil {
+		return err
+	}
+	if !r.ok() {
+		return r.err()
+	}
+	t.auth.Update(r.Resp)
+	return nil
 }
 
 // Client for the ecobee API.
@@ -25,12 +97,13 @@ type Client struct {
 }
 
 // New egobee client.
-func New(ts TokenStore) *Client {
+func New(appID string, ts TokenStore) *Client {
 	return &Client{
 		Client: http.Client{
 			Transport: &authorizingTransport{
 				auth:      ts,
 				transport: http.DefaultTransport,
+				appID:     appID,
 			},
 		},
 	}

--- a/egobee_test.go
+++ b/egobee_test.go
@@ -8,28 +8,29 @@ import (
 )
 
 type fakeTokenStore struct {
+	access  string
+	refresh string
+	vf      time.Duration
 }
 
 func (s *fakeTokenStore) AccessToken() string {
-	return "thisisanaccesstoken"
+	return s.access
 }
 
 func (s *fakeTokenStore) RefreshToken() string {
-	return "thisisarefreshtoken"
+	return s.refresh
 }
 
 func (s *fakeTokenStore) ValidFor() time.Duration {
-	return time.Minute * 30
+	return s.vf
 }
 
-func (s *fakeTokenStore) Update(r *TokenRefreshResponse) {
-	return
-}
+func (s *fakeTokenStore) Update(r *TokenRefreshResponse) {}
 
 func TestAuthorizingTransport(t *testing.T) {
 	clientForTest := http.Client{
 		Transport: &authorizingTransport{
-			auth:      &fakeTokenStore{},
+			auth:      &fakeTokenStore{"thisisanaccesstoken", "thisisarefreshtoken", time.Minute * 30},
 			transport: http.DefaultTransport,
 		},
 	}
@@ -45,4 +46,83 @@ func TestAuthorizingTransport(t *testing.T) {
 		t.Errorf("unexpected error GETting from test server: %v", err)
 	}
 	res.Body.Close()
+}
+
+func TestReauthResponse_OK(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		resp *reauthResponse
+		want bool
+	}{
+		{
+			name: "response only",
+			resp: &reauthResponse{
+				Resp: &TokenRefreshResponse{},
+			},
+			want: true,
+		},
+		{
+			// This should be impossible, but we'll test it anyway.
+			name: "response and error",
+			resp: &reauthResponse{
+				Err:  &AuthorizationErrorResponse{},
+				Resp: &TokenRefreshResponse{},
+			},
+			want: false,
+		},
+		{
+			name: "error only",
+			resp: &reauthResponse{
+				Err: &AuthorizationErrorResponse{},
+			},
+			want: false,
+		},
+		{
+			name: "empty non-nil receiver (zero)",
+			resp: &reauthResponse{},
+			want: false,
+		},
+		{
+			name: "nil receiver",
+			want: false,
+		},
+	} {
+		if got := tt.resp.ok(); got != tt.want {
+			t.Errorf("%v: got %v, wanted %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestAuthorizingTransport_ShouldReauth(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		ts   TokenStore
+		want bool
+	}{
+		{
+			name: "shouldn't reauth",
+			ts:   &fakeTokenStore{"foo", "bar", time.Minute * 30},
+			want: false,
+		},
+		{
+			name: "reauth for time",
+			ts:   &fakeTokenStore{"foo", "bar", time.Second},
+			want: true,
+		},
+		{
+			name: "reauth for token",
+			ts:   &fakeTokenStore{"", "", time.Minute * 30},
+			want: true,
+		},
+		{
+			name: "reauth for both", // just for good measure.
+			ts:   &fakeTokenStore{"", "", time.Second},
+			want: true,
+		},
+	} {
+		testTransport := &authorizingTransport{auth: tt.ts}
+		if got := testTransport.shouldReauth(); got != tt.want {
+			t.Errorf("%v: got %v, wanted %v", tt.name, got, tt.want)
+		}
+	}
 }

--- a/token.go
+++ b/token.go
@@ -3,6 +3,7 @@ package egobee
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"regexp"
 	"sync"
 	"time"
@@ -103,6 +104,12 @@ func (r *AuthorizationErrorResponse) ParseString(payload string) error {
 	return r.Parse([]byte(payload))
 }
 
+// Populate behaves the same as Parse, but reads the content from an io.Reader.
+func (r *AuthorizationErrorResponse) Populate(reader io.Reader) error {
+	d := json.NewDecoder(reader)
+	return d.Decode(r)
+}
+
 // TokenRefreshResponse is returned by the ecobee API on toke refresh.
 // See https://www.ecobee.com/home/developer/api/documentation/v1/auth/token-refresh.shtml
 type TokenRefreshResponse struct {
@@ -111,6 +118,26 @@ type TokenRefreshResponse struct {
 	ExpiresIn    TokenDuration `json:"expires_in"`
 	RefreshToken string        `json:"refresh_token"`
 	Scope        Scope         `json:"scope"`
+}
+
+// Parse a response payload into the receiving TokenRefreshResponse. This will
+// naturally fail if the payload is not an TokenRefreshResponse.
+func (r *TokenRefreshResponse) Parse(payload []byte) error {
+	if err := json.Unmarshal(payload, r); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ParseString behaves the same as Parse, but on a string.
+func (r *TokenRefreshResponse) ParseString(payload string) error {
+	return r.Parse([]byte(payload))
+}
+
+// Populate behaves the same as Parse, but reads the content from an io.Reader.
+func (r *TokenRefreshResponse) Populate(reader io.Reader) error {
+	d := json.NewDecoder(reader)
+	return d.Decode(r)
 }
 
 // TokenStore for ecobee Access and Refresh tokens.

--- a/types.go
+++ b/types.go
@@ -362,6 +362,60 @@ type SecuritySettings struct {
 	VacationAccess  bool   `json:"vacationAccess"`
 }
 
+// SelectionType defines the type of selection to perform.
+// See https://www.ecobee.com/home/developer/api/documentation/v1/objects/Selection.shtml.
+type SelectionType string
+
+var (
+	// SelectionTypeRegistered returns Thermostats registered to the current user
+	// Only usable with Smart thermostats, does not work on EMS thermostats and
+	// may not be used by a Utility who is not the owner of thermostats.
+	SelectionTypeRegistered SelectionType = "registered"
+
+	// SelectionTypeThermostats selects only those thermostats listed in the CSV
+	// SelectionMatch. No spaces in the CSV string. There is a limit of 25
+	// identifiers per request.
+	SelectionTypeThermostats SelectionType = "thermostats"
+
+	// SelectionTypeManagementSet selects all thermostats for a given management
+	// set defined by the Management/Utility account. This is only available to
+	// Management/Utility accounts.
+	SelectionTypeManagementSet SelectionType = "managementSet"
+)
+
+// Selection defines the resources and information to return as part of a
+// response. It is required in all requests, but some selection fields are only
+// meaningful in certain request types.
+// See https://www.ecobee.com/home/developer/api/documentation/v1/objects/Selection.shtml
+type Selection struct {
+	SelectionType               SelectionType `json:"selectionType"`
+	SelectionMatch              string        `json:"selectionMatch"`
+	IncludeRuntime              bool          `json:"includeRuntime"`
+	IncludeExtendedRuntime      bool          `json:"includeExtendedRuntime"`
+	IncludeElectricity          bool          `json:"includeElectricity"`
+	IncludeSettings             bool          `json:"includeSettings"`
+	IncludeLocation             bool          `json:"includeLocation"`
+	IncludeProgram              bool          `json:"includeProgram"`
+	IncludeEvents               bool          `json:"includeEvents"`
+	IncludeDevice               bool          `json:"includeDevice"`
+	IncludeTechnician           bool          `json:"includeTechnician"`
+	IncludeUtility              bool          `json:"includeUtility"`
+	IncludeManagement           bool          `json:"includeManagement"`
+	IncludeAlerts               bool          `json:"includeAlerts"`
+	IncludeReminders            bool          `json:"includeReminders"`
+	IncludeWeather              bool          `json:"includeWeather"`
+	IncludeHouseDetails         bool          `json:"includeHouseDetails"`
+	IncludeOemCfg               bool          `json:"includeOemCfg"`
+	IncludeEquipmentStatus      bool          `json:"includeEquipmentStatus"`
+	IncludeNotificationSettings bool          `json:"includeNotificationSettings"`
+	IncludePrivacy              bool          `json:"includePrivacy"`
+	IncludeVersion              bool          `json:"includeVersion"`
+	IncludeSecuritySettings     bool          `json:"includeSecuritySettings"`
+	IncludeSensors              bool          `json:"includeSensors"`
+	IncludeAudio                bool          `json:"includeAudio"`
+	IncludeEnergy               bool          `json:"includeEnergy"`
+}
+
 // Sensor represents a sensor connected to the thermostat. Sensors may not be
 // modified using the API, however some configuration may occur through the web
 // portal.


### PR DESCRIPTION
The `authorizingTransport` now refreshes tokens when necessary from the Ecobee Token API and updates the TokenStore.

I've also added `Selection` and `SelectionType` types from the Ecobee API in anticipation of adding functionality to the client.