### PR TITLE
Return error when the thermostatSummary API returns non-2xx status

### DIFF
--- a/client_functions.go
+++ b/client_functions.go
@@ -57,6 +57,9 @@ func (c *Client) ThermostatSummary() (*ThermostatSummary, error) {
 		log.Fatalf("Failed to Do request: %v", err)
 	}
 	defer res.Body.Close()
+	if (res.StatusCode / 100) != 2 {
+		return nil, fmt.Errorf("non-ok status response from API: %v", res.Status)
+	}
 	ts := &ThermostatSummary{}
 	if err := json.NewDecoder(res.Body).Decode(ts); err != nil {
 		return nil, err


### PR DESCRIPTION
When the thermostatSummary API returns a non-OK status code, return the details as a Go error to be handled by callers of `Client.ThermostatSummary()`.