### PR TITLE
Move ThermostatSummary to types.go

### DIFF
--- a/client_functions.go
+++ b/client_functions.go
@@ -10,20 +10,9 @@ import (
 
 const ecobeeThermostatSumaryURL = "https://api.ecobee.com/1/thermostatSummary"
 
-// ThermostatSummary describes Thermostats and their status according to the
-// API.
-// See https://www.ecobee.com/home/developer/api/documentation/v1/operations/get-thermostat-summary.shtml
-type ThermostatSummary struct {
-	RevisionList    []string `json:"revisionList,omitempty"`
-	ThermostatCount int      `json:"thermostatCount,omitempty"`
-	StatusList      []string `json:"statusList,omitempty"`
-	Status          struct {
-		Code    int    `json:"code,omitempty"`
-		Message string `json:"message,omitempty"`
-	} `json:"status,omitempty"`
-}
-
-type jsonSelection struct {
+// summarySelection wraps a Selection, and serializes to the format expected by
+// the thermostatSummary API.
+type summarySelection struct {
 	Selection Selection `json:"selection"`
 }
 
@@ -33,7 +22,7 @@ type jsonSelection struct {
 // data.
 // See https://www.ecobee.com/home/developer/api/documentation/v1/operations/get-thermostat-summary.shtml
 func (c *Client) ThermostatSummary() (*ThermostatSummary, error) {
-	s := &jsonSelection{
+	s := &summarySelection{
 		Selection: Selection{
 			SelectionType: SelectionTypeRegistered,
 			IncludeAlerts: true,

--- a/types.go
+++ b/types.go
@@ -615,6 +615,19 @@ type Thermostat struct {
 // TODO(cfunkhouser): reverse engineer this struct.
 type ThermostatReminder2 struct{}
 
+// ThermostatSummary describes Thermostats and their status according to the
+// API.
+// See https://www.ecobee.com/home/developer/api/documentation/v1/operations/get-thermostat-summary.shtml
+type ThermostatSummary struct {
+	RevisionList    []string `json:"revisionList,omitempty"`
+	ThermostatCount int      `json:"thermostatCount,omitempty"`
+	StatusList      []string `json:"statusList,omitempty"`
+	Status          struct {
+		Code    int    `json:"code,omitempty"`
+		Message string `json:"message,omitempty"`
+	} `json:"status,omitempty"`
+}
+
 // Utility the Thermostat belongs to. May not be modified.
 // See https://www.ecobee.com/home/developer/api/documentation/v1/objects/Utility.shtml
 type Utility struct {


### PR DESCRIPTION
Relocate the types declared in `client_functions.go` to the appropriate location in `types.go` to fix #12.