### PR TITLE
Correct the persistent store behavior

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,7 @@ go 1.12
 
 require (
 	github.com/imdario/mergo v0.3.7
+	github.com/kr/pretty v0.1.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,13 @@
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/token_test.go
+++ b/token_test.go
@@ -160,7 +160,7 @@ func TestAuthorizationErrorResponse_Parse(t *testing.T) {
 }
 
 func TestNewPersistentTokenStore(t *testing.T) {
-	testStorePath := "C:\\Users\\Christian Funkhouser\\AppData\\Local\\tempStore"
+	testStorePath := "/tmp/testStore"
 	tokenRefreshResponse := &TokenRefreshResponse{
 		AccessToken:  "anAccessToken",
 		TokenType:    "Bearer",
@@ -187,7 +187,7 @@ func TestNewPersistentTokenStore(t *testing.T) {
 }
 
 func TestNewPersistentTokenStoreFromDisk(t *testing.T) {
-	testStorePath := "C:\\Users\\Christian Funkhouser\\AppData\\Local\\tempStore"
+	testStorePath := "/tmp/testStore"
 	testFileData := []byte(`{"accessToken":"anAccessToken","refreshToken":"aRefreshToken","validUntil":"2015-02-23T14:51:00.000000000-05:00"}`)
 	err := ioutil.WriteFile(testStorePath, testFileData, 0640)
 	tokenStore, err := NewPersistentTokenFromDisk(testStorePath)
@@ -214,7 +214,7 @@ func TestPersistentStoreUpdateLeavesOnlyASingleEntryInFile(t *testing.T) {
 	now = func() time.Time { return ttime }
 	defer func() { now = origNow }()
 
-	testStorePath := "C:\\Users\\Christian Funkhouser\\AppData\\Local\\tempStore"
+	testStorePath := "/tmp/testStore"
 	tokenRefreshResponse := &TokenRefreshResponse{
 		AccessToken:  "anAccessToken",
 		TokenType:    "Bearer",


### PR DESCRIPTION
The previous implementation of the persistent store accumulated JSON objects each time a refresh was triggered. The proper behavior is to overwrite the file, instead of appending.